### PR TITLE
[chore] Correct asf label

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -20,7 +20,7 @@ github:
   homepage: https://dolphinscheduler.apache.org/
   labels:
     - dolphinscheduler
-    - MLops
+    - mlops
   enabled_merge_buttons:
     squash: true
     merge: false


### PR DESCRIPTION
Invalid GitHub label 'MLops' - must be lowercase alphanumerical and <= 35 characters!